### PR TITLE
feat : Share establishment and clean

### DIFF
--- a/Mobile/Carto/lib/utils/accordeons.dart
+++ b/Mobile/Carto/lib/utils/accordeons.dart
@@ -6,7 +6,7 @@ import '../models/establishment.dart';
 class HoursAccordion extends StatefulWidget {
   final List<DayOfTheWeekElemDto> schedule;
 
-  HoursAccordion({required this.schedule});
+  const HoursAccordion({super.key, required this.schedule});
 
   @override
   _HoursAccordionState createState() => _HoursAccordionState();
@@ -57,7 +57,7 @@ class _HoursAccordionState extends State<HoursAccordion> {
             BoxShadow(
               color: Colors.black.withOpacity(0.1),
               blurRadius: 4,
-              offset: Offset(0, 2),
+              offset: const Offset(0, 2),
             ),
           ],
         ),
@@ -68,7 +68,7 @@ class _HoursAccordionState extends State<HoursAccordion> {
             highlightColor: Colors.transparent,
           ),
           child: ExpansionTile(
-            tilePadding: EdgeInsets.symmetric(horizontal: 16, vertical: 5),
+            tilePadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 5),
             title: const Text(
               "Horaires",
               style: TextStyle(

--- a/Mobile/Carto/lib/utils/buttons.dart
+++ b/Mobile/Carto/lib/utils/buttons.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'dart:math' as math;
 
@@ -29,13 +28,13 @@ class WhiteSquareIconButton extends StatelessWidget {
               BoxShadow(
                 color: Colors.black.withOpacity(0.1),
                 blurRadius: 4,
-                offset: Offset(0, 2),
+                offset: const Offset(0, 2),
               ),
             ],
           ),
           child: Icon(
             icon,
-            color: Color(0xFF005CFF),
+            color: const Color(0xFF005CFF),
           ),
         ),
       ),
@@ -70,7 +69,7 @@ class WhiteSquareIconInvertedButton extends StatelessWidget {
               BoxShadow(
                 color: Colors.black.withOpacity(0.1),
                 blurRadius: 4,
-                offset: Offset(0, 2),
+                offset: const Offset(0, 2),
               ),
             ],
           ),
@@ -79,7 +78,7 @@ class WhiteSquareIconInvertedButton extends StatelessWidget {
             transform: Matrix4.rotationY(math.pi),
             child: Icon(
               icon,
-              color: Color(0xFF005CFF),
+              color: const Color(0xFF005CFF),
             ),
           ),
         ),

--- a/Mobile/Carto/lib/utils/tags.dart
+++ b/Mobile/Carto/lib/utils/tags.dart
@@ -10,9 +10,9 @@ class GameTag extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: EdgeInsets.symmetric(horizontal: 12, vertical: 5),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
       decoration: BoxDecoration(
-        border: Border.all(color: Color(0xFFEB663B), width: 1.5),
+        border: Border.all(color: const Color(0xFFEB663B), width: 1.5),
         borderRadius: BorderRadius.circular(15),
       ),
       child: Row(
@@ -70,9 +70,9 @@ class InfoTag extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: EdgeInsets.symmetric(horizontal: 12, vertical: 5),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
       decoration: BoxDecoration(
-        border: Border.all(color: Color(0xFF005CFF), width: 1.5),
+        border: Border.all(color: const Color(0xFF005CFF), width: 1.5),
         borderRadius: BorderRadius.circular(15),
       ),
       child: Text(
@@ -115,9 +115,9 @@ class PriceTag extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: EdgeInsets.symmetric(horizontal: 12, vertical: 5),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
       decoration: BoxDecoration(
-        border: Border.all(color: Color(0xFF005CFF), width: 1.5),
+        border: Border.all(color: const Color(0xFF005CFF), width: 1.5),
         borderRadius: BorderRadius.circular(15),
       ),
       child: Text(
@@ -144,11 +144,11 @@ class EstablishmentInfo extends StatelessWidget {
     infoTags.add(PriceTag(price: establishment.price));
 
     if (establishment.proximityTransport) {
-      infoTags.add(InfoTag(infoName: "Proximité Transport"));
+      infoTags.add(const InfoTag(infoName: "Proximité Transport"));
     }
 
     if (establishment.accessPRM) {
-      infoTags.add(InfoTag(infoName: "Accès PMR"));
+      infoTags.add(const InfoTag(infoName: "Accès PMR"));
     }
 
     return Padding(

--- a/Mobile/Carto/lib/views/pages/establishement_details_page.dart
+++ b/Mobile/Carto/lib/views/pages/establishement_details_page.dart
@@ -3,7 +3,6 @@ import 'package:carto/utils/accordeons.dart';
 import 'package:carto/utils/buttons.dart';
 import 'package:carto/utils/tags.dart';
 import 'package:flutter/material.dart';
-import 'dart:math' as math;
 import 'package:url_launcher/url_launcher.dart';
 import 'package:share_plus/share_plus.dart';
 
@@ -97,13 +96,6 @@ class _EstablishmentDisplayPageState extends State<EstablishmentDisplayPage> {
                         ),
                        Column(
                          children: [
-                           IconButton(
-                             icon: const Icon(Icons.favorite_border,
-                                 color: Color(0xFF005CFF)),
-                             onPressed: () {
-                               // TODO implements to fav
-                             },
-                           ),
                            establishment.phoneNumber.isEmpty ?
                              const SizedBox() :
                              IconButton(

--- a/Mobile/Carto/lib/views/pages/establishement_details_page.dart
+++ b/Mobile/Carto/lib/views/pages/establishement_details_page.dart
@@ -5,6 +5,7 @@ import 'package:carto/utils/tags.dart';
 import 'package:flutter/material.dart';
 import 'dart:math' as math;
 import 'package:url_launcher/url_launcher.dart';
+import 'package:share_plus/share_plus.dart';
 
 class EstablishmentDisplayPage extends StatefulWidget {
   const EstablishmentDisplayPage({super.key});
@@ -122,7 +123,7 @@ class _EstablishmentDisplayPageState extends State<EstablishmentDisplayPage> {
                              icon: const Icon(Icons.share,
                                  color: Color(0xFF005CFF)),
                              onPressed: () {
-                               // TODO implements to share
+                               shareEstablishment(establishment);
                              },
                            ),
                            establishment.site.isEmpty ?
@@ -205,5 +206,33 @@ class _EstablishmentDisplayPageState extends State<EstablishmentDisplayPage> {
         ),
       ),
     );
+  }
+
+  void shareEstablishment(Establishment establishment) async {
+    String text = "${establishment.name}\n"
+        "Au : ${establishment.address}\n"
+        "Jeux disponibles :\n";
+    for(GameTypeDto game in
+    establishment.gameTypeDtoList)
+    {
+      text += "   ${game.gameType.value} : "
+          "${game.numberOfGame}\n";
+    }
+    if(establishment.site.isNotEmpty) {
+      text += "Site web : ${establishment.site}\n";
+    }
+    if(establishment.phoneNumber.isNotEmpty || establishment.emailAddress.isNotEmpty) {
+      text += "Contact :\n";
+      if(establishment.phoneNumber.isNotEmpty) {
+        text += "   Téléphone : ${establishment.phoneNumber}\n";
+      }
+      if(establishment.emailAddress.isNotEmpty) {
+        text += "   Mail : ${establishment.emailAddress}\n";
+      }
+    }
+    final result = await Share.share(text);
+    if(result.status != ShareResultStatus.success){
+      throw Exception('Could not share');
+    }
   }
 }

--- a/Mobile/Carto/lib/views/pages/home_page.dart
+++ b/Mobile/Carto/lib/views/pages/home_page.dart
@@ -13,7 +13,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
-    MapWidget map = MapWidget();
+    MapWidget map = const MapWidget();
     return LayoutBuilder(
       builder: (context, constraints) {
         return Scaffold(

--- a/Mobile/Carto/lib/views/pages/suggestion_page.dart
+++ b/Mobile/Carto/lib/views/pages/suggestion_page.dart
@@ -96,7 +96,7 @@ class _SuggestionPageState extends State<SuggestionPage> {
       minRes = "${time.minute}";
     }
 
-    return "${hourRes}:${minRes}:00";
+    return "$hourRes:$minRes:00";
   }
 
   @override
@@ -130,31 +130,31 @@ class _SuggestionPageState extends State<SuggestionPage> {
                   child: const Text("Suggérer un établissement"),
                   onPressed: () {
                     List<DayOfTheWeekElemDto> days = [];
-                    days.add(new DayOfTheWeekElemDto(DayOfTheWeek.monday,
+                    days.add(DayOfTheWeekElemDto(DayOfTheWeek.monday,
                       convertToString(_weekOpeningHour[0][0]),
                       convertToString(_weekOpeningHour[0][1]), _weekOpening[0])
                     );
-                    days.add(new DayOfTheWeekElemDto(DayOfTheWeek.tuesday,
+                    days.add(DayOfTheWeekElemDto(DayOfTheWeek.tuesday,
                       convertToString(_weekOpeningHour[1][0]),
                       convertToString(_weekOpeningHour[1][1]), _weekOpening[1])
                     );
-                    days.add(new DayOfTheWeekElemDto(DayOfTheWeek.wednesday,
+                    days.add(DayOfTheWeekElemDto(DayOfTheWeek.wednesday,
                       convertToString(_weekOpeningHour[2][0]),
                       convertToString(_weekOpeningHour[2][1]), _weekOpening[2])
                     );
-                    days.add(new DayOfTheWeekElemDto(DayOfTheWeek.thursday,
+                    days.add(DayOfTheWeekElemDto(DayOfTheWeek.thursday,
                       convertToString(_weekOpeningHour[3][0]),
                       convertToString(_weekOpeningHour[3][1]), _weekOpening[3])
                     );
-                    days.add(new DayOfTheWeekElemDto(DayOfTheWeek.friday,
+                    days.add(DayOfTheWeekElemDto(DayOfTheWeek.friday,
                       convertToString(_weekOpeningHour[4][0]),
                       convertToString(_weekOpeningHour[4][1]), _weekOpening[4])
                     );
-                    days.add(new DayOfTheWeekElemDto(DayOfTheWeek.saturday,
+                    days.add(DayOfTheWeekElemDto(DayOfTheWeek.saturday,
                       convertToString(_weekOpeningHour[5][0]),
                       convertToString(_weekOpeningHour[5][1]), _weekOpening[5])
                     );
-                    days.add(new DayOfTheWeekElemDto(DayOfTheWeek.sunday,
+                    days.add(DayOfTheWeekElemDto(DayOfTheWeek.sunday,
                       convertToString(_weekOpeningHour[6][0]),
                       convertToString(_weekOpeningHour[6][1]), _weekOpening[6])
                     );

--- a/Mobile/Carto/lib/views/services/establishment_service.dart
+++ b/Mobile/Carto/lib/views/services/establishment_service.dart
@@ -1,5 +1,4 @@
 import 'package:carto/models/establishment.dart';
-import 'package:carto/models/establishment_data.dart';
 import 'package:dio/dio.dart';
 
 class EstablishmentService{
@@ -13,6 +12,6 @@ class EstablishmentService{
  }
 
  void createEstablishment(Establishment establishment) async {
-  var response = await dio.post("https://carto.onrender.com/establishment",data: establishment.toJson());
+  await dio.post("https://carto.onrender.com/establishment",data: establishment.toJson());
  }
 }

--- a/Mobile/Carto/lib/views/services/location_service.dart
+++ b/Mobile/Carto/lib/views/services/location_service.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'dart:async';
@@ -23,7 +22,7 @@ class LocationService {
     bool hasPermission = await _requestLocationPermission();
     if (!hasPermission) return;
 
-    LocationSettings locationSettings = LocationSettings(
+    LocationSettings locationSettings = const LocationSettings(
       accuracy: LocationAccuracy.high,
       distanceFilter: 2,
     );

--- a/Mobile/Carto/lib/views/widgets/map_widget.dart
+++ b/Mobile/Carto/lib/views/widgets/map_widget.dart
@@ -29,8 +29,8 @@ class _MapWidgetState extends State<MapWidget> {
   bool isFirstLoad = true;
   bool _isDarkMode = false;
   final LocationService _locationService = LocationService();
-  double default_latitude = 50.63294;
-  double default_longitude = 3.05843;
+  double defaultLatitude = 50.63294;
+  double defaultLongitude = 3.05843;
 
   late Future<List<Establishment>> _establishmentsFuture;
 
@@ -65,11 +65,11 @@ class _MapWidgetState extends State<MapWidget> {
             future: _establishmentsFuture,
             builder: (context, snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
-                return Center(child: CircularProgressIndicator());
+                return const Center(child: CircularProgressIndicator());
               } else if (snapshot.hasError) {
                 return Center(child: Text('Erreur : ${snapshot.error}'));
               } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
-                return Center(child: Text('Aucun établissement trouvé'));
+                return const Center(child: Text('Aucun établissement trouvé'));
               }
 
               // Marker for establishments
@@ -84,7 +84,7 @@ class _MapWidgetState extends State<MapWidget> {
                       '/etablishment_detail',
                       arguments: {'establishment': establishment},
                     );
-                  }, icon: Icon(Icons.location_on, color: Colors.red, size: 40)),
+                  }, icon: const Icon(Icons.location_on, color: Colors.red, size: 40)),
                 );
               }).toList();
 
@@ -94,7 +94,7 @@ class _MapWidgetState extends State<MapWidget> {
                   width: 80.0,
                   height: 80.0,
                   point: LatLng(_currentPosition!.latitude, _currentPosition!.longitude),
-                  child: Icon(Icons.circle_rounded, color: Colors.blue, size: 20),
+                  child: const Icon(Icons.circle_rounded, color: Colors.blue, size: 20),
                 ));
               }
 
@@ -103,7 +103,7 @@ class _MapWidgetState extends State<MapWidget> {
                 options: MapOptions(
                   initialCenter: _currentPosition != null
                       ? LatLng(_currentPosition!.latitude, _currentPosition!.longitude)
-                      : LatLng(default_latitude, default_longitude),
+                      : LatLng(defaultLatitude, defaultLongitude),
                   initialZoom: 15,
                   minZoom: 6,
                   maxZoom: 19,
@@ -149,9 +149,9 @@ class _MapWidgetState extends State<MapWidget> {
               onPressed: () {
                 _currentPosition != null
                     ? _mapController.move(LatLng(_currentPosition!.latitude, _currentPosition!.longitude), 15)
-                    : _mapController.move(LatLng(default_latitude, default_longitude), 15);
+                    : _mapController.move(LatLng(defaultLatitude, defaultLongitude), 15);
               },
-              child: Icon(Icons.center_focus_strong_rounded),
+              child: const Icon(Icons.center_focus_strong_rounded),
             ),
           ),
           // Button for recenter on map
@@ -165,24 +165,11 @@ class _MapWidgetState extends State<MapWidget> {
                   '/suggestion',
                 );
               },
-              child: Icon(Icons.add),
+              child: const Icon(Icons.add),
             ),
           ),
         ],
       ),
-    );
-  }
-
-  Widget _lightModeTileBuilder(
-      BuildContext context, Widget tileWidget, TileImage tile) {
-    return ColorFiltered(
-      colorFilter: const ColorFilter.matrix(<double>[
-        1, 0, 0, 0, 0, // Red channel
-        0, 1, 0, 0, 0, // Green channel
-        0, 0, 1, 0, 0, // Blue channel
-        0, 0, 0, 1, 0, // Alpha channel
-      ]),
-      child: tileWidget,
     );
   }
 
@@ -194,19 +181,6 @@ class _MapWidgetState extends State<MapWidget> {
         0.2126, 0.7152, 0.0722, 0, 0,
         0.2126, 0.7152, 0.0722, 0, 0,
         0,      0,      0,      1, 0,
-      ]),
-      child: tileWidget,
-    );
-  }
-
-  Widget _darkenedModeTileBuilder(
-      BuildContext context, Widget tileWidget, TileImage tile) {
-    return ColorFiltered(
-      colorFilter: const ColorFilter.matrix(<double>[
-        0.75, 0,    0,    0, 0,
-        0,    0.75, 0,    0, 0,
-        0,    0,    0.75, 0, 0,
-        0,    0,    0,    1, 0
       ]),
       child: tileWidget,
     );

--- a/Mobile/Carto/pubspec.lock
+++ b/Mobile/Carto/pubspec.lock
@@ -174,6 +174,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   crypto:
     dependency: transitive
     description:
@@ -230,6 +238,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.3"
   file:
     dependency: transitive
     description:
@@ -297,10 +313,10 @@ packages:
     dependency: "direct main"
     description:
       name: geolocator
-      sha256: "0ec58b731776bc43097fcf751f79681b6a8f6d3bc737c94779fe9f1ad73c1a81"
+      sha256: d2ec66329cab29cb297d51d96c067d457ca519dca8589665fa0b82ebacb7dbe4
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.1"
+    version: "13.0.2"
   geolocator_android:
     dependency: transitive
     description:
@@ -313,10 +329,10 @@ packages:
     dependency: transitive
     description:
       name: geolocator_apple
-      sha256: bc2aca02423ad429cb0556121f56e60360a2b7d694c8570301d06ea0c00732fd
+      sha256: "6154ea2682563f69fc0125762ed7e91e7ed85d0b9776595653be33918e064807"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.7"
+    version: "2.3.8+1"
   geolocator_platform_interface:
     dependency: transitive
     description:
@@ -417,10 +433,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: ea1432d167339ea9b5bb153f0571d0039607a873d6e04e0117af043f14a1fd4b
+      sha256: c2fcb3920cf2b6ae6845954186420fca40bc0a8abcc84903b7801f17d7050d7c
       url: "https://pub.dev"
     source: hosted
-    version: "6.8.0"
+    version: "6.9.0"
   latlong2:
     dependency: "direct main"
     description:
@@ -473,10 +489,10 @@ packages:
     dependency: transitive
     description:
       name: logger
-      sha256: "697d067c60c20999686a0add96cf6aba723b3aa1f83ecf806a8097231529ec32"
+      sha256: be4b23575aac7ebf01f225a241eb7f6b5641eeaf43c6a8613510fc2f8cf187d1
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.5.0"
   logging:
     dependency: transitive
     description:
@@ -557,6 +573,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "8c4967f8b7cb46dc914e178daa29813d83ae502e0529d7b0478330616a691ef7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.14"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: f234384a3fdd67f989b4d54a5d73ca2a6c422fa55ae694381ae0f4375cd1ea16
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   permission_handler:
     dependency: "direct main"
     description:
@@ -585,10 +649,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_html
-      sha256: af26edbbb1f2674af65a8f4b56e1a6f526156bc273d0e65dd8075fab51c78851
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3+2"
+    version: "0.1.3+5"
   permission_handler_platform_interface:
     dependency: transitive
     description:
@@ -605,6 +669,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.1"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -661,6 +733,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: "9c9bafd4060728d7cdb2464c341743adbd79d327cb067ec7afb64583540b47c8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.2"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: c57c0bbfec7142e3a0f55633be504b796af72e60e3c791b44d5a017b985f7a48
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.1"
   shelf:
     dependency: transitive
     description:
@@ -673,10 +761,10 @@ packages:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: "073c147238594ecd0d193f3456a5fe91c4b0abbcc68bf5cd95b36c4e194ac611"
+      sha256: cc36c297b52866d203dbf9332263c94becc2fe0ceaa9681d07b6ef9807023b67
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -835,7 +923,7 @@ packages:
     source: hosted
     version: "2.3.2"
   url_launcher_web:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: url_launcher_web
       sha256: "772638d3b34c779ede05ba3d38af34657a05ac55b06279ea6edd409e323dca8e"
@@ -906,6 +994,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: "84ba388638ed7a8cb3445a320c8273136ab2631cd5f2c57888335504ddab1bc2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.8.0"
   wkt_parser:
     dependency: transitive
     description:
@@ -914,6 +1010,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   yaml:
     dependency: transitive
     description:

--- a/Mobile/Carto/pubspec.yaml
+++ b/Mobile/Carto/pubspec.yaml
@@ -48,7 +48,8 @@ dependencies:
   intl: ^0.19.0
 
   url_launcher: ^6.3.1
-  url_launcher_web: ^2.3.3
+
+  share_plus: ^10.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Merge the feature for sharing an establishment data to other application.

When tap on button share, I can choose the application where I want to show the resume for the establishment.

The resume of the establishment contains : 
- the name
- the address
- the games ("name : number")
- the website (if exists)
- the phone number (if exists)
- the mail (if exists)

Respond to User Story SCRUM-78

Cleaned the code to remove dead code and improve performance.